### PR TITLE
Allow empty strings in response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2198,8 +2198,8 @@ async function processGenericAccessTokenResponse(
     throw new OPE('"response" body "refresh_token" property must be a non-empty string')
   }
 
-  if (json.scope !== undefined && !validateString(json.scope)) {
-    throw new OPE('"response" body "scope" property must be a non-empty string')
+  if (json.scope !== undefined && typeof json.scope !== 'string') {
+    throw new OPE('"response" body "scope" property must be a string')
   }
 
   if (!ignoreIdToken) {

--- a/test/authorization_code.test.ts
+++ b/test/authorization_code.test.ts
@@ -308,7 +308,7 @@ test('processAuthorizationCodeOAuth2Response() without ID Tokens', async (t) => 
       getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer', scope: null })),
     ),
     {
-      message: '"response" body "scope" property must be a non-empty string',
+      message: '"response" body "scope" property must be a string',
     },
   )
   await t.throwsAsync(

--- a/test/device_flow.test.ts
+++ b/test/device_flow.test.ts
@@ -400,7 +400,7 @@ test('processDeviceCodeResponse() without ID Tokens', async (t) => {
       getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer', scope: null })),
     ),
     {
-      message: '"response" body "scope" property must be a non-empty string',
+      message: '"response" body "scope" property must be a string',
     },
   )
   await t.throwsAsync(

--- a/test/refresh_token.test.ts
+++ b/test/refresh_token.test.ts
@@ -206,7 +206,7 @@ test('processRefreshTokenResponse() without ID Tokens', async (t) => {
       getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer', scope: null })),
     ),
     {
-      message: '"response" body "scope" property must be a non-empty string',
+      message: '"response" body "scope" property must be a string',
     },
   )
   await t.throwsAsync(


### PR DESCRIPTION
GitHub allows for an empty scope string to request public user information: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes. Alternatively I could add an `ignoreScopes` option like the other "ignore" flags but that looks like it'll get overwhelming quickly. Happy to modify it as needed.

Edit: Alternatively it could also be a `skip` symbol. Let me know if either of these work for you and I can update the PR.