### PR TITLE
Fix clientSecretBasic() encoding issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -957,8 +957,8 @@ function formUrlEncode(token: string) {
  * specified in RFC6749.
  */
 function clientSecretBasic(clientId: string, clientSecret: string) {
-  const username = formUrlEncode(clientId)
-  const password = formUrlEncode(clientSecret)
+  const username = decodeURIComponent(formUrlEncode(clientId))
+  const password = decodeURIComponent(formUrlEncode(clientSecret))
   const credentials = btoa(`${username}:${password}`)
   return `Basic ${credentials}`
 }


### PR DESCRIPTION
clientId and clientSecret are formUrlEncoded before being base64 encoded. This causes the auth to fail if there are special characters in those values.
Examples I found online use unescape(formUrlEncode(value)) when creating a Basic auth header, however unescape is deprecated and to the best of my knowledge the replacement for this use case is decodeURIComponent