### PR TITLE
Remove unnecessary error for id_token existing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3398,11 +3398,6 @@ export async function processAuthorizationCodeOAuth2Response(
   }
 
   if (result.id_token !== undefined) {
-    if (typeof result.id_token === 'string' && result.id_token.length) {
-      throw new OPE(
-        'Unexpected ID Token returned, use processAuthorizationCodeOpenIDResponse() for OpenID Connect callback processing',
-      )
-    }
     // @ts-expect-error
     delete result.id_token
   }


### PR DESCRIPTION
Having `id_token` in the jwt is bad form and the provider should stop doing that, but it's likely not enough to throw an error and prevent the system from moving forward.