### PR TITLE
fix: disable content type checking to allow text/plain responses for certain providers while processing valid JSON

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3310,7 +3310,8 @@ async function processGenericAccessTokenResponse(
   }
 
   assertReadableResponse(response)
-  assertApplicationJson(response)
+  // comment this because some providers (China's wechat) return text/plain but the body is valid JSON
+  // assertApplicationJson(response)
   let json: JsonValue
   try {
     json = await response.json()


### PR DESCRIPTION
China's wechat api response content-type is `text/plain` but the body is valid JSON, I comment this line it will all work fine.