### PR TITLE
feat: add Client-Initiated Backchannel Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following features are currently in scope and implemented in this software:
 
 - Authorization Server Metadata discovery
 - Authorization Code Flow (profiled under OpenID Connect 1.0, OAuth 2.0, OAuth 2.1, and FAPI 2.0), with PKCE
-- Refresh Token, Device Authorization, and Client Credentials Grants
+- Refresh Token, Device Authorization, Client-Initiated Backchannel Authentication, and Client Credentials Grants
 - Demonstrating Proof-of-Possession at the Application Layer (DPoP)
 - Token Introspection and Revocation
 - Pushed Authorization Requests (PAR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,13 @@ Support from the community to continue maintaining and improving this module is 
 - [clientCredentialsGrantRequest](functions/clientCredentialsGrantRequest.md)
 - [processClientCredentialsResponse](functions/processClientCredentialsResponse.md)
 
+## Client-Initiated Backchannel Authentication
+
+- [backchannelAuthenticationGrantRequest](functions/backchannelAuthenticationGrantRequest.md)
+- [backchannelAuthenticationRequest](functions/backchannelAuthenticationRequest.md)
+- [processBackchannelAuthenticationGrantResponse](functions/processBackchannelAuthenticationGrantResponse.md)
+- [processBackchannelAuthenticationResponse](functions/processBackchannelAuthenticationResponse.md)
+
 ## DPoP
 
 - [DPoP](functions/DPoP.md)
@@ -184,6 +191,8 @@ Support from the community to continue maintaining and improving this module is 
 
 - [AuthorizationDetails](interfaces/AuthorizationDetails.md)
 - [AuthorizationServer](interfaces/AuthorizationServer.md)
+- [BackchannelAuthenticationRequestOptions](interfaces/BackchannelAuthenticationRequestOptions.md)
+- [BackchannelAuthenticationResponse](interfaces/BackchannelAuthenticationResponse.md)
 - [Client](interfaces/Client.md)
 - [ClientCredentialsGrantRequestOptions](interfaces/ClientCredentialsGrantRequestOptions.md)
 - [ConfirmationClaims](interfaces/ConfirmationClaims.md)

--- a/docs/functions/backchannelAuthenticationGrantRequest.md
+++ b/docs/functions/backchannelAuthenticationGrantRequest.md
@@ -1,0 +1,31 @@
+# Function: backchannelAuthenticationGrantRequest()
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+▸ **backchannelAuthenticationGrantRequest**(`as`, `client`, `clientAuthentication`, `authReqId`, `options`?): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+Performs a Backchannel Authentication Grant request at the
+[`as.token_endpoint`](../interfaces/AuthorizationServer.md#token_endpoint).
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `as` | [`AuthorizationServer`](../interfaces/AuthorizationServer.md) | Authorization Server Metadata. |
+| `client` | [`Client`](../interfaces/Client.md) | Client Metadata. |
+| `clientAuthentication` | [`ClientAuth`](../type-aliases/ClientAuth.md) | Client Authentication Method. |
+| `authReqId` | `string` | Unique identifier to identify the authentication request. This is the [`auth_req_id`](../interfaces/BackchannelAuthenticationResponse.md#auth_req_id) retrieved from [processBackchannelAuthenticationResponse](processBackchannelAuthenticationResponse.md). |
+| `options`? | [`TokenEndpointRequestOptions`](../interfaces/TokenEndpointRequestOptions.md) | - |
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+## See
+
+ - [OpenID Connect Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#token_request)
+ - [RFC 9449 - OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP)](https://www.rfc-editor.org/rfc/rfc9449.html#name-dpop-access-token-request)

--- a/docs/functions/backchannelAuthenticationRequest.md
+++ b/docs/functions/backchannelAuthenticationRequest.md
@@ -1,0 +1,30 @@
+# Function: backchannelAuthenticationRequest()
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+▸ **backchannelAuthenticationRequest**(`as`, `client`, `clientAuthentication`, `parameters`, `options`?): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+Performs a Backchannel Authentication Request at the
+[`as.backchannel_authentication_endpoint`](../interfaces/AuthorizationServer.md#backchannel_authentication_endpoint).
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `as` | [`AuthorizationServer`](../interfaces/AuthorizationServer.md) | Authorization Server Metadata. |
+| `client` | [`Client`](../interfaces/Client.md) | Client Metadata. |
+| `clientAuthentication` | [`ClientAuth`](../type-aliases/ClientAuth.md) | Client Authentication Method. |
+| `parameters` | [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `string`\> \| [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) \| `string`[][] | Backchannel Authentication Request parameters. |
+| `options`? | [`BackchannelAuthenticationRequestOptions`](../interfaces/BackchannelAuthenticationRequestOptions.md) | - |
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+## See
+
+[OpenID Connect Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request)

--- a/docs/functions/deviceCodeGrantRequest.md
+++ b/docs/functions/deviceCodeGrantRequest.md
@@ -18,7 +18,7 @@ Performs a Device Authorization Grant request at the
 | `as` | [`AuthorizationServer`](../interfaces/AuthorizationServer.md) | Authorization Server Metadata. |
 | `client` | [`Client`](../interfaces/Client.md) | Client Metadata. |
 | `clientAuthentication` | [`ClientAuth`](../type-aliases/ClientAuth.md) | Client Authentication Method. |
-| `deviceCode` | `string` | Device Code. |
+| `deviceCode` | `string` | Device Code. This is the [`device_code`](../interfaces/DeviceAuthorizationResponse.md#device_code) retrieved from [processDeviceAuthorizationResponse](processDeviceAuthorizationResponse.md). |
 | `options`? | [`TokenEndpointRequestOptions`](../interfaces/TokenEndpointRequestOptions.md) | - |
 
 ## Returns

--- a/docs/functions/processBackchannelAuthenticationGrantResponse.md
+++ b/docs/functions/processBackchannelAuthenticationGrantResponse.md
@@ -1,0 +1,33 @@
+# Function: processBackchannelAuthenticationGrantResponse()
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+▸ **processBackchannelAuthenticationGrantResponse**(`as`, `client`, `response`, `options`?): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`TokenEndpointResponse`](../interfaces/TokenEndpointResponse.md)\>
+
+Validates Backchannel Authentication Grant [Response](https://developer.mozilla.org/docs/Web/API/Response) instance to be one coming from the
+[`as.token_endpoint`](../interfaces/AuthorizationServer.md#token_endpoint).
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `as` | [`AuthorizationServer`](../interfaces/AuthorizationServer.md) | Authorization Server Metadata. |
+| `client` | [`Client`](../interfaces/Client.md) | Client Metadata. |
+| `response` | [`Response`](https://developer.mozilla.org/docs/Web/API/Response) | Resolved value from [backchannelAuthenticationGrantRequest](backchannelAuthenticationGrantRequest.md). |
+| `options`? | [`JWEDecryptOptions`](../interfaces/JWEDecryptOptions.md) | - |
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`TokenEndpointResponse`](../interfaces/TokenEndpointResponse.md)\>
+
+Resolves with an object representing the parsed successful response. OAuth 2.0 protocol
+  style errors are rejected using [ResponseBodyError](../classes/ResponseBodyError.md). WWW-Authenticate HTTP Header
+  challenges are rejected with [WWWAuthenticateChallengeError](../classes/WWWAuthenticateChallengeError.md).
+
+## See
+
+[OpenID Connect Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#token_request)

--- a/docs/functions/processBackchannelAuthenticationResponse.md
+++ b/docs/functions/processBackchannelAuthenticationResponse.md
@@ -1,0 +1,32 @@
+# Function: processBackchannelAuthenticationResponse()
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+▸ **processBackchannelAuthenticationResponse**(`as`, `client`, `response`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`BackchannelAuthenticationResponse`](../interfaces/BackchannelAuthenticationResponse.md)\>
+
+Validates [Response](https://developer.mozilla.org/docs/Web/API/Response) instance to be one coming from the
+[`as.backchannel_authentication_endpoint`](../interfaces/AuthorizationServer.md#backchannel_authentication_endpoint).
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `as` | [`AuthorizationServer`](../interfaces/AuthorizationServer.md) | Authorization Server Metadata. |
+| `client` | [`Client`](../interfaces/Client.md) | Client Metadata. |
+| `response` | [`Response`](https://developer.mozilla.org/docs/Web/API/Response) | Resolved value from [backchannelAuthenticationRequest](backchannelAuthenticationRequest.md). |
+
+## Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`BackchannelAuthenticationResponse`](../interfaces/BackchannelAuthenticationResponse.md)\>
+
+Resolves with an object representing the parsed successful response. OAuth 2.0 protocol
+  style errors are rejected using [ResponseBodyError](../classes/ResponseBodyError.md). WWW-Authenticate HTTP Header
+  challenges are rejected with [WWWAuthenticateChallengeError](../classes/WWWAuthenticateChallengeError.md).
+
+## See
+
+[OpenID Connect Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request)

--- a/docs/interfaces/BackchannelAuthenticationRequestOptions.md
+++ b/docs/interfaces/BackchannelAuthenticationRequestOptions.md
@@ -1,0 +1,61 @@
+# Interface: BackchannelAuthenticationRequestOptions
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+## Properties
+
+### ~~\[allowInsecureRequests\]?~~
+
+• `optional` **\[allowInsecureRequests\]**: `boolean`
+
+See [allowInsecureRequests](../variables/allowInsecureRequests.md).
+
+#### Deprecated
+
+***
+
+### \[customFetch\]()?
+
+• `optional` **\[customFetch\]**: (`url`, `options`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+See [customFetch](../variables/customFetch.md).
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `url` | `string` | URL the request is being made sent to [fetch](https://developer.mozilla.org/docs/Web/API/Window/fetch) as the `resource` argument |
+| `options` | [`CustomFetchOptions`](CustomFetchOptions.md)\<`"POST"`, [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams)\> | Options otherwise sent to [fetch](https://developer.mozilla.org/docs/Web/API/Window/fetch) as the `options` argument |
+
+#### Returns
+
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`Response`](https://developer.mozilla.org/docs/Web/API/Response)\>
+
+***
+
+### headers?
+
+• `optional` **headers**: [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type)\<`string`, `string`\> \| [`string`, `string`][] \| [`Headers`](https://developer.mozilla.org/docs/Web/API/Headers)
+
+Headers to additionally send with the HTTP request(s) triggered by this function's invocation.
+
+***
+
+### signal?
+
+• `optional` **signal**: [`AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal) \| () => [`AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal)
+
+An AbortSignal instance, or a factory returning one, to abort the HTTP request(s) triggered by
+this function's invocation.
+
+#### Example
+
+A 5000ms timeout AbortSignal for every request
+
+```js
+let signal = () => AbortSignal.timeout(5_000) // Note: AbortSignal.timeout may not yet be available in all runtimes.
+```

--- a/docs/interfaces/BackchannelAuthenticationResponse.md
+++ b/docs/interfaces/BackchannelAuthenticationResponse.md
@@ -1,0 +1,36 @@
+# Interface: BackchannelAuthenticationResponse
+
+[💗 Help the project](https://github.com/sponsors/panva)
+
+Support from the community to continue maintaining and improving this module is welcome. If you find the module useful, please consider supporting the project by [becoming a sponsor](https://github.com/sponsors/panva).
+
+***
+
+## Indexable
+
+ \[`parameter`: `string`\]: `undefined` \| [`JsonValue`](../type-aliases/JsonValue.md)
+
+## Properties
+
+### auth\_req\_id
+
+• `readonly` **auth\_req\_id**: `string`
+
+Unique identifier to identify the authentication request.
+
+***
+
+### expires\_in
+
+• `readonly` **expires\_in**: `number`
+
+The lifetime in seconds of the "auth_req_id".
+
+***
+
+### interval?
+
+• `readonly` `optional` **interval**: `number`
+
+The minimum amount of time in seconds that the client should wait between polling requests to
+the token endpoint.

--- a/examples/backchannel_authentication_grant.ts
+++ b/examples/backchannel_authentication_grant.ts
@@ -1,0 +1,85 @@
+import * as oauth from 'oauth4webapi'
+
+// Prerequisites
+
+let issuer!: URL // Authorization server's Issuer Identifier URL
+let algorithm!:
+  | 'oauth2' /* For .well-known/oauth-authorization-server discovery */
+  | 'oidc' /* For .well-known/openid-configuration discovery */
+  | undefined /* Defaults to 'oidc' */
+let client_id!: string
+
+// End of prerequisites
+
+const as = await oauth
+  .discoveryRequest(issuer, { algorithm })
+  .then((response) => oauth.processDiscoveryResponse(issuer, response))
+
+const client: oauth.Client = { client_id }
+const clientAuth = oauth.None()
+
+let auth_req_id: string
+let interval: number
+
+// Backchannel Authentication Request & Response
+{
+  const parameters = new URLSearchParams()
+  parameters.set('scope', 'openid')
+
+  const response = await oauth.backchannelAuthenticationRequest(as, client, clientAuth, parameters)
+
+  const result = await oauth.processBackchannelAuthenticationResponse(as, client, response)
+
+  console.log('Backchannel Authentication Response', result)
+  ;({ auth_req_id, interval = 5 } = result)
+}
+
+// Backchannel Authentication Grant Request & Response
+let access_token: string
+let sub: string
+{
+  let success: oauth.TokenEndpointResponse | undefined = undefined
+  function wait() {
+    return new Promise((resolve) => {
+      setTimeout(resolve, interval * 1000)
+    })
+  }
+
+  while (success === undefined) {
+    await wait()
+    const response = await oauth.backchannelAuthenticationGrantRequest(
+      as,
+      client,
+      clientAuth,
+      auth_req_id,
+    )
+
+    success = await oauth
+      .processBackchannelAuthenticationGrantResponse(as, client, response)
+      .catch((err) => {
+        if (err instanceof oauth.ResponseBodyError) {
+          switch (err.error) {
+            case 'slow_down':
+              interval += 5
+            case 'authorization_pending':
+              return undefined
+          }
+        }
+        throw err
+      })
+  }
+
+  console.log('Access Token Response', success)
+  ;({ access_token } = success)
+  const claims = oauth.getValidatedIdTokenClaims(success)!
+  console.log('ID Token Claims', claims)
+  ;({ sub } = claims)
+}
+
+// UserInfo Request
+{
+  const response = await oauth.userInfoRequest(as, client, access_token)
+
+  const result = await oauth.processUserInfoResponse(as, client, sub, response)
+  console.log('UserInfo Response', result)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5556,7 +5556,9 @@ export async function processDeviceAuthorizationResponse(
  * @param as Authorization Server Metadata.
  * @param client Client Metadata.
  * @param clientAuthentication Client Authentication Method.
- * @param deviceCode Device Code.
+ * @param deviceCode Device Code. This is the
+ *   {@link DeviceAuthorizationResponse.device_code `device_code`} retrieved from
+ *   {@link processDeviceAuthorizationResponse}.
  *
  * @group Device Authorization Grant
  *

--- a/tap/end2end-ciba.ts
+++ b/tap/end2end-ciba.ts
@@ -1,0 +1,134 @@
+import type QUnit from 'qunit'
+
+import { setup } from './helper.js'
+import * as lib from '../src/index.js'
+import { keys } from './keys.js'
+import * as jose from 'jose'
+
+export default (QUnit: QUnit) => {
+  const { module, test } = QUnit
+  module('end2end-ciba.ts')
+
+  const alg = 'ES256'
+
+  for (const dpop of [true, false]) {
+    test(`end-to-end CIBA flow ${dpop ? 'w/ dpop' : ''}`, async (t) => {
+      const kp = await keys[alg]
+      const { client, issuerIdentifier } = await setup(
+        alg,
+        kp,
+        'client_secret_post',
+        false,
+        false,
+        false,
+        ['refresh_token', 'urn:openid:params:grant-type:ciba'],
+        false,
+      )
+      const DPoPKeyPair = await lib.generateKeyPair(alg)
+      const DPoP = dpop
+        ? lib.DPoP(client, DPoPKeyPair, {
+            [lib.modifyAssertion](h, p) {
+              t.equal(h.alg, 'ES256')
+              p.foo = 'bar'
+            },
+          })
+        : undefined
+
+      const clientAuth = lib.ClientSecretBasic(client.client_secret as string)
+
+      const as = await lib
+        .discoveryRequest(issuerIdentifier, { [lib.allowInsecureRequests]: true })
+        .then((response) => lib.processDiscoveryResponse(issuerIdentifier, response))
+
+      const resource = 'urn:example:resource:jwt'
+      const params = new URLSearchParams()
+      params.set('resource', resource)
+      params.set('scope', 'openid api:write')
+      params.set('login_hint', 'user')
+
+      let response = await lib.backchannelAuthenticationRequest(as, client, clientAuth, params, {
+        [lib.allowInsecureRequests]: true,
+      })
+
+      let result = await lib.processBackchannelAuthenticationResponse(as, client, response)
+      const { auth_req_id, interval = 5 } = result
+
+      await fetch('http://localhost:3000/ciba-sim', {
+        method: 'POST',
+        body: new URLSearchParams({
+          action: 'allow',
+          auth_req_id,
+        }),
+      })
+
+      {
+        const backchannelAuthenticationGrantRequest = () =>
+          lib.backchannelAuthenticationGrantRequest(as, client, clientAuth, auth_req_id, {
+            DPoP,
+            [lib.allowInsecureRequests]: true,
+          })
+        let response = await backchannelAuthenticationGrantRequest()
+
+        const processBackchannelAuthenticationGrantResponse = () =>
+          lib.processBackchannelAuthenticationGrantResponse(as, client, response)
+        let result: lib.TokenEndpointResponse | undefined
+        while (!result) {
+          try {
+            result = await processBackchannelAuthenticationGrantResponse()
+          } catch {
+            await new Promise((resolve) => setTimeout(resolve, interval * 1000))
+            response = await backchannelAuthenticationGrantRequest()
+          }
+        }
+
+        const { access_token, token_type } = result
+        t.ok(access_token)
+        t.equal(token_type, dpop ? 'dpop' : 'bearer')
+
+        const verb = ['GET', 'POST', 'PATCH'][Math.floor(Math.random() * 3)]
+
+        await lib.protectedResourceRequest(
+          access_token,
+          verb,
+          new URL('http://localhost:3001/resource'),
+          undefined,
+          undefined,
+          {
+            DPoP,
+            [lib.allowInsecureRequests]: true,
+            async [lib.customFetch](...params: Parameters<typeof fetch>) {
+              const url = new URL(params[0] as string)
+              const { headers, method } = params[1]!
+              const request = new Request(url, { headers, method })
+
+              const jwtAccessToken = await lib.validateJwtAccessToken(as, request, resource, {
+                [lib.allowInsecureRequests]: true,
+              })
+
+              t.propContains(jwtAccessToken, {
+                client_id: client.client_id,
+                iss: as.issuer,
+                aud: resource,
+              })
+
+              if (DPoP) {
+                t.equal(
+                  jwtAccessToken.cnf!.jkt,
+                  await jose.calculateJwkThumbprint(await jose.exportJWK(DPoPKeyPair.publicKey)),
+                )
+
+                t.propContains(await jose.decodeJwt(request.headers.get('dpop')!), { foo: 'bar' })
+              } else {
+                t.equal(jwtAccessToken.cnf, undefined)
+              }
+
+              return new Response()
+            },
+          },
+        )
+      }
+
+      t.ok(1)
+    })
+  }
+}

--- a/tap/helper.ts
+++ b/tap/helper.ts
@@ -93,6 +93,7 @@ export async function setup(
     require_auth_time: random(),
     default_max_age: authEndpoint ? (random() ? 30 : undefined) : undefined,
     grant_types: grantTypes,
+    backchannel_token_delivery_mode: 'poll',
     jwks: makeJwks(),
   }
 

--- a/tap/import_map.json
+++ b/tap/import_map.json
@@ -6,6 +6,7 @@
     "./callback.js": "./callback.ts",
     "./end2end-client-credentials.js": "./end2end-client-credentials.ts",
     "./end2end-device-code.js": "./end2end-device-code.ts",
+    "./end2end-ciba.js": "./end2end-ciba.ts",
     "./end2end.js": "./end2end.ts",
     "./env.js": "./env.ts",
     "./generate.js": "./generate.ts",

--- a/tap/run.ts
+++ b/tap/run.ts
@@ -16,6 +16,9 @@ export default async (QUnit: QUnit, done: (details: QUnit.DoneDetails) => void) 
     import('./random.js'),
     import('./request_object.js'),
   ])
+  if (!(typeof navigator !== 'undefined' && navigator.userAgent?.startsWith?.('Mozilla/5.0 '))) {
+    modules.push(await import('./end2end-ciba.js'))
+  }
   for (const { default: module } of modules) {
     await module(QUnit)
   }

--- a/tap/server.mjs
+++ b/tap/server.mjs
@@ -35,6 +35,16 @@ const provider = new Provider('http://localhost:3000', {
     jwtResponseModes: { enabled: true },
     jwtUserinfo: { enabled: true },
     pushedAuthorizationRequests: { enabled: true },
+    ciba: {
+      enabled: true,
+      processLoginHint(ctx, loginHint) {
+        return loginHint
+      },
+      verifyUserCode() {},
+      validateRequestContext() {},
+      triggerAuthenticationDevice() {},
+      deliveryModes: ['poll'],
+    },
     resourceIndicators: {
       enabled: true,
       getResourceServerInfo: (ctx, resource) => ({
@@ -90,6 +100,54 @@ provider.use((ctx, next) => {
 })
 
 provider.use(async (ctx, next) => {
+  if (ctx.path === '/ciba-sim' && ctx.method === 'POST') {
+    const body = await raw(ctx.req, {
+      length: ctx.request.length,
+      encoding: ctx.charset,
+    })
+
+    const params = new URLSearchParams(body.toString())
+    const auth_req_id = params.get('auth_req_id')
+    const action = params.get('action')
+
+    const request = await provider.BackchannelAuthenticationRequest.find(auth_req_id)
+
+    if (action === 'allow') {
+      const client = await provider.Client.find(request.clientId)
+      const grant = new provider.Grant({
+        client,
+        accountId: request.accountId,
+      })
+      grant.addOIDCScope(request.scope)
+      let claims = []
+      if (request.claims.id_token) {
+        claims = claims.concat(Object.keys(request.claims.id_token))
+      }
+      if (request.claims.userinfo) {
+        claims = claims.concat(Object.keys(request.claims.userinfo))
+      }
+      grant.addOIDCClaims(claims)
+      // eslint-disable-next-line no-restricted-syntax
+      for (const indicator of request.params.resource) {
+        grant.addResourceScope(indicator, request.params.scope)
+      }
+      await grant.save()
+      await provider
+        .backchannelResult(request, grant, {
+          acr: 'urn:mace:incommon:iap:silver',
+          authTime: Math.floor(Date.now() / 1000),
+        })
+        .catch(() => {})
+    } else {
+      await provider
+        .backchannelResult(request, new errors.AccessDenied('end-user cancelled request'))
+        .catch(() => {})
+    }
+
+    ctx.body = { done: true }
+    return undefined
+  }
+
   if (ctx.URL.pathname === '/drive' && ctx.method === 'POST') {
     let browser
     try {

--- a/test/ciba.test.ts
+++ b/test/ciba.test.ts
@@ -1,0 +1,698 @@
+import anyTest, { type TestFn } from 'ava'
+import setup, {
+  client,
+  endpoint,
+  getResponse,
+  issuer,
+  setupJwks,
+  teardown,
+  type ContextWithAlgs,
+  UA,
+} from './_setup.js'
+import * as jose from 'jose'
+import * as lib from '../src/index.js'
+import * as tools from './_tools.js'
+
+const test = anyTest as TestFn<ContextWithAlgs>
+
+test.before(setup)
+test.after(teardown)
+test.before(setupJwks)
+
+const tClient: lib.Client = { ...client, token_endpoint_auth_method: 'none' }
+
+test('backchannelAuthenticationRequest()', async (t) => {
+  await t.throwsAsync(
+    lib.backchannelAuthenticationRequest(issuer, tClient, lib.None(), new URLSearchParams()),
+    {
+      message:
+        'authorization server metadata does not contain a valid "as.backchannel_authentication_endpoint"',
+    },
+  )
+
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    backchannel_authentication_endpoint: endpoint('ciba-1'),
+  }
+
+  t.context
+    .intercept({
+      path: '/ciba-1',
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'user-agent': UA,
+      },
+      body(body) {
+        const params = new URLSearchParams(body)
+        return (
+          params.get('client_id') === client.client_id &&
+          params.get('resource') === 'urn:example:resource'
+        )
+      },
+    })
+    .reply(200, '')
+    .times(3)
+
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationRequest(
+      tIssuer,
+      tClient,
+      lib.None(),
+      new URLSearchParams({ resource: 'urn:example:resource' }),
+    ),
+  )
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationRequest(tIssuer, tClient, lib.None(), {
+      resource: 'urn:example:resource',
+    }),
+  )
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationRequest(tIssuer, tClient, lib.None(), [
+      ['resource', 'urn:example:resource'],
+    ]),
+  )
+})
+
+test('backchannelAuthenticationRequest() w/ Custom Headers', async (t) => {
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    backchannel_authentication_endpoint: endpoint('ciba-headers'),
+  }
+
+  t.context
+    .intercept({
+      path: '/ciba-headers',
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'foo',
+        foo: 'bar',
+      },
+    })
+    .reply(200, '')
+    .times(3)
+
+  const entries = [
+    ['accept', 'will be overwritten'],
+    ['user-agent', 'foo'],
+    ['foo', 'bar'],
+  ]
+  for (const headers of [
+    entries,
+    Object.fromEntries(entries),
+    new Headers(Object.fromEntries(entries)),
+  ]) {
+    await t.notThrowsAsync(
+      lib.backchannelAuthenticationRequest(tIssuer, tClient, lib.None(), new URLSearchParams(), {
+        headers,
+      }),
+    )
+  }
+})
+
+test('processBackchannelAuthenticationResponse()', async (t) => {
+  await t.throwsAsync(lib.processBackchannelAuthenticationResponse(issuer, client, null as any), {
+    message: '"response" must be an instance of Response',
+  })
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(issuer, client, getResponse('', { status: 404 })),
+    {
+      message:
+        '"response" is not a conform Backchannel Authentication Endpoint response (unexpected HTTP status code)',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse('{"', { status: 200 }),
+    ),
+    {
+      message: 'failed to parse "response" body as JSON',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse('null', { status: 200 }),
+    ),
+    {
+      message: '"response" body must be a top level object',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse('[]', { status: 200 }),
+    ),
+    {
+      message: '"response" body must be a top level object',
+    },
+  )
+
+  const validResponse = {
+    auth_req_id: 'auth_req_id',
+    expires_in: 300,
+    interval: 5,
+  }
+
+  t.deepEqual(
+    await lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify(validResponse), { status: 200 }),
+    ),
+    validResponse,
+  )
+
+  await t.notThrowsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ ...validResponse, verification_uri_complete: undefined }), {
+        status: 200,
+      }),
+    ),
+  )
+
+  await t.notThrowsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ ...validResponse, interval: undefined }), { status: 200 }),
+    ),
+  )
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ ...validResponse, auth_req_id: undefined }), { status: 200 }),
+    ),
+    {
+      message: '"response" body "auth_req_id" property must be a string',
+    },
+  )
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ ...validResponse, expires_in: undefined }), { status: 200 }),
+    ),
+    {
+      message: '"response" body "expires_in" property must be a number',
+    },
+  )
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ ...validResponse, interval: null }), { status: 200 }),
+    ),
+    {
+      message: '"response" body "interval" property must be a number',
+    },
+  )
+})
+
+test('backchannelAuthenticationGrantRequest()', async (t) => {
+  await t.throwsAsync(
+    lib.backchannelAuthenticationGrantRequest(issuer, tClient, lib.None(), 'auth_req_id'),
+    {
+      message: 'authorization server metadata does not contain a valid "as.token_endpoint"',
+    },
+  )
+
+  await t.throwsAsync(
+    lib.backchannelAuthenticationGrantRequest(issuer, tClient, lib.None(), null as any),
+    {
+      message: '"authReqId" must be a string',
+    },
+  )
+
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    token_endpoint: endpoint('token-1'),
+  }
+
+  t.context
+    .intercept({
+      path: '/token-1',
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+      },
+      body(body) {
+        const params = new URLSearchParams(body)
+        return (
+          params.get('grant_type') === 'urn:openid:params:grant-type:ciba' &&
+          params.get('auth_req_id') === 'auth_req_id'
+        )
+      },
+    })
+    .reply(200, { access_token: 'token', token_type: 'Bearer' })
+
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id'),
+  )
+})
+
+test('backchannelAuthenticationGrantRequest() w/ Extra Parameters', async (t) => {
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    token_endpoint: endpoint('token-2'),
+  }
+
+  t.context
+    .intercept({
+      path: '/token-2',
+      method: 'POST',
+      body(body) {
+        const params = new URLSearchParams(body)
+        return params.get('resource') === 'urn:example:resource'
+      },
+    })
+    .reply(200, { access_token: 'token', token_type: 'Bearer' })
+    .times(3)
+
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id', {
+      additionalParameters: new URLSearchParams('resource=urn:example:resource'),
+    }),
+  )
+
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id', {
+      additionalParameters: {
+        resource: 'urn:example:resource',
+      },
+    }),
+  )
+
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id', {
+      additionalParameters: [['resource', 'urn:example:resource']],
+    }),
+  )
+})
+
+test('backchannelAuthenticationGrantRequest() w/ Custom Headers', async (t) => {
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    token_endpoint: endpoint('token-headers'),
+  }
+
+  t.context
+    .intercept({
+      path: '/token-headers',
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'foo',
+        foo: 'bar',
+      },
+    })
+    .reply(200, { access_token: 'token', token_type: 'Bearer' })
+    .times(3)
+
+  const entries = [
+    ['accept', 'will be overwritten'],
+    ['user-agent', 'foo'],
+    ['foo', 'bar'],
+  ]
+  for (const headers of [
+    entries,
+    Object.fromEntries(entries),
+    new Headers(Object.fromEntries(entries)),
+  ]) {
+    await t.notThrowsAsync(
+      lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id', {
+        headers,
+      }),
+    )
+  }
+})
+
+test('backchannelAuthenticationGrantRequest() w/ DPoP', async (t) => {
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    token_endpoint: endpoint('token-3'),
+  }
+
+  t.context
+    .intercept({
+      path: '/token-3',
+      method: 'POST',
+      headers: {
+        dpop: /.+/,
+      },
+    })
+    .reply(200, { access_token: 'token', token_type: 'DPoP' })
+
+  const DPoP = lib.DPoP(tClient, await lib.generateKeyPair('ES256'))
+  await t.notThrowsAsync(
+    lib.backchannelAuthenticationGrantRequest(tIssuer, tClient, lib.None(), 'auth_req_id', {
+      DPoP,
+    }),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() without ID Tokens', async (t) => {
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(issuer, client, null as any),
+    {
+      message: '"response" must be an instance of Response',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse('', { status: 404 }),
+    ),
+    {
+      message: '"response" is not a conform Token Endpoint response (unexpected HTTP status code)',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(issuer, client, getResponse('{"')),
+    {
+      message: 'failed to parse "response" body as JSON',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(issuer, client, getResponse('null')),
+    {
+      message: '"response" body must be a top level object',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(issuer, client, getResponse('[]')),
+    {
+      message: '"response" body must be a top level object',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ token_type: 'Bearer' })),
+    ),
+    {
+      message: '"response" body "access_token" property must be a string',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ access_token: 'token' })),
+    ),
+    {
+      message: '"response" body "token_type" property must be a string',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          expires_in: new Date().toUTCString(),
+        }),
+      ),
+    ),
+    {
+      message: '"response" body "expires_in" property must be a number',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer', scope: null })),
+    ),
+    {
+      message: '"response" body "scope" property must be a string',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(
+        JSON.stringify({ access_token: 'token', token_type: 'Bearer', refresh_token: null }),
+      ),
+    ),
+    {
+      message: '"response" body "refresh_token" property must be a string',
+    },
+  )
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer', id_token: null })),
+    ),
+    {
+      message: '"response" body "id_token" property must be a string',
+    },
+  )
+
+  const response = await lib.processBackchannelAuthenticationGrantResponse(
+    issuer,
+    client,
+    getResponse(
+      JSON.stringify({
+        access_token: 'token',
+        token_type: 'Bearer',
+        expires_in: 60,
+        scope: 'api:read',
+        refresh_token: 'refresh_token',
+      }),
+    ),
+  )
+
+  t.deepEqual(response, {
+    access_token: 'token',
+    token_type: 'bearer',
+    expires_in: 60,
+    scope: 'api:read',
+    refresh_token: 'refresh_token',
+  })
+
+  t.is(lib.getValidatedIdTokenClaims(response), undefined)
+
+  const err = await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      issuer,
+      client,
+      getResponse(JSON.stringify({ error: 'invalid_grant' }), { status: 400 }),
+    ),
+  )
+
+  t.true(
+    err instanceof lib.ResponseBodyError && err.error === 'invalid_grant' && err.status === 400,
+  )
+
+  await lib.processBackchannelAuthenticationGrantResponse(
+    issuer,
+    client,
+    getResponse(JSON.stringify({ access_token: 'token', token_type: 'Bearer' })),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() - ignores signatures', async (t) => {
+  await t.notThrowsAsync(
+    lib
+      .processBackchannelAuthenticationGrantResponse(
+        { ...issuer, id_token_signing_alg_values_supported: ['ES256'] },
+        client,
+        getResponse(
+          JSON.stringify({
+            access_token: 'token',
+            token_type: 'Bearer',
+            id_token: tools.mangleJwtSignature(
+              await new jose.SignJWT({})
+                .setProtectedHeader({ alg: 'ES256' })
+                .setIssuer(issuer.issuer)
+                .setSubject('urn:example:subject')
+                .setAudience(client.client_id)
+                .setExpirationTime('5m')
+                .setIssuedAt()
+                .sign(t.context.ES256.privateKey),
+            ),
+          }),
+        ),
+      )
+      .then(async (result) => {
+        t.assert(lib.getValidatedIdTokenClaims(result))
+      }),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() with an ID Token (alg signalled)', async (t) => {
+  const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
+
+  await t.notThrowsAsync(
+    lib
+      .processBackchannelAuthenticationGrantResponse(
+        { ...tIssuer, id_token_signing_alg_values_supported: ['ES256'] },
+        client,
+        getResponse(
+          JSON.stringify({
+            access_token: 'token',
+            token_type: 'Bearer',
+            id_token: await new jose.SignJWT({})
+              .setProtectedHeader({ alg: 'ES256' })
+              .setIssuer(issuer.issuer)
+              .setSubject('urn:example:subject')
+              .setAudience(client.client_id)
+              .setExpirationTime('5m')
+              .setIssuedAt()
+              .sign(t.context.ES256.privateKey),
+          }),
+        ),
+      )
+      .then(async (result) => {
+        t.assert(lib.getValidatedIdTokenClaims(result))
+        t.throws(() => lib.getValidatedIdTokenClaims({ ...result }), {
+          name: 'TypeError',
+          message: '"ref" was already garbage collected or did not resolve from the proper sources',
+        })
+      }),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() with an ID Token (alg specified)', async (t) => {
+  const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
+
+  await t.notThrowsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      tIssuer,
+      { ...client, id_token_signed_response_alg: 'ES256' },
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          id_token: await new jose.SignJWT({})
+            .setProtectedHeader({ alg: 'ES256' })
+            .setIssuer(issuer.issuer)
+            .setSubject('urn:example:subject')
+            .setAudience(client.client_id)
+            .setExpirationTime('5m')
+            .setIssuedAt()
+            .sign(t.context.ES256.privateKey),
+        }),
+      ),
+    ),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() with an ID Token (alg default)', async (t) => {
+  const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
+
+  await t.notThrowsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      tIssuer,
+      client,
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          id_token: await new jose.SignJWT({})
+            .setProtectedHeader({ alg: 'RS256' })
+            .setIssuer(issuer.issuer)
+            .setSubject('urn:example:subject')
+            .setAudience(client.client_id)
+            .setExpirationTime('5m')
+            .setIssuedAt()
+            .sign(t.context.RS256.privateKey),
+        }),
+      ),
+    ),
+  )
+})
+
+test('processBackchannelAuthenticationGrantResponse() with an ID Token (alg mismatches)', async (t) => {
+  const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      tIssuer,
+      client,
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          id_token: await new jose.SignJWT({})
+            .setProtectedHeader({ alg: 'ES256' })
+            .setIssuer(issuer.issuer)
+            .setSubject('urn:example:subject')
+            .setAudience(client.client_id)
+            .setExpirationTime('5m')
+            .setIssuedAt()
+            .sign(t.context.ES256.privateKey),
+        }),
+      ),
+    ),
+    { message: 'unexpected JWT "alg" header parameter' },
+  )
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      {
+        ...tIssuer,
+        id_token_signing_alg_values_supported: ['RS256'],
+      },
+      client,
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          id_token: await new jose.SignJWT({})
+            .setProtectedHeader({ alg: 'ES256' })
+            .setIssuer(issuer.issuer)
+            .setSubject('urn:example:subject')
+            .setAudience(client.client_id)
+            .setExpirationTime('5m')
+            .setIssuedAt()
+            .sign(t.context.ES256.privateKey),
+        }),
+      ),
+    ),
+    { message: 'unexpected JWT "alg" header parameter' },
+  )
+
+  await t.throwsAsync(
+    lib.processBackchannelAuthenticationGrantResponse(
+      tIssuer,
+      {
+        ...client,
+        id_token_signed_response_alg: 'RS256',
+      },
+      getResponse(
+        JSON.stringify({
+          access_token: 'token',
+          token_type: 'Bearer',
+          id_token: await new jose.SignJWT({})
+            .setProtectedHeader({ alg: 'ES256' })
+            .setIssuer(issuer.issuer)
+            .setSubject('urn:example:subject')
+            .setAudience(client.client_id)
+            .setExpirationTime('5m')
+            .setIssuedAt()
+            .sign(t.context.ES256.privateKey),
+        }),
+      ),
+    ),
+    { message: 'unexpected JWT "alg" header parameter' },
+  )
+})


### PR DESCRIPTION
Adds [Client-Initiated Backchannel Authentication](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html) intended for poll and ping delivery modes (validating ping requests out of scope).