### PR TITLE
fix: treat an ID Token "nonce" claim value of '' as undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3901,7 +3901,7 @@ export async function processAuthorizationCodeResponse(
   options?: ProcessAuthorizationCodeResponseOptions,
 ): Promise<TokenEndpointResponse> {
   if (
-    typeof options?.expectedNonce === 'string' ||
+    typeof options?.expectedNonce === 'string' && options.expectedNonce !== '' ||
     typeof options?.maxAge === 'number' ||
     options?.requireIdToken
   ) {
@@ -3932,6 +3932,7 @@ async function processAuthorizationCodeOpenIDResponse(
 
   switch (expectedNonce) {
     case undefined:
+    case '':
       expectedNonce = expectNoNonce
       break
     case expectNoNonce:
@@ -3979,7 +3980,7 @@ async function processAuthorizationCodeOpenIDResponse(
   }
 
   if (expectedNonce === expectNoNonce) {
-    if (claims.nonce !== undefined) {
+    if (claims.nonce !== undefined && claims.nonce !== '') {
       throw OPE('unexpected ID Token "nonce" claim value', JWT_CLAIM_COMPARISON, {
         expected: undefined,
         claims,
@@ -4020,7 +4021,7 @@ async function processAuthorizationCodeOAuth2Response(
       }
     }
 
-    if (claims.nonce !== undefined) {
+    if (claims.nonce !== undefined && claims.nonce !== '') {
       throw OPE('unexpected ID Token "nonce" claim value', JWT_CLAIM_COMPARISON, {
         expected: undefined,
         claims,


### PR DESCRIPTION
This allows `''` (empty string) to be declared as an expected value for the ID Token `nonce` claim and treated as `expectNoNonce`. When this value is returned in a response (such as from Slack's OpenID Connect provider), treat it the same as `undefined`. Tested by applying the same changes to oauth4webapi v3.5.5 shipped with Immich and successfully completing OAuth login.

Closes #186