### PR TITLE
Check the validity of auth_time claim if it is required to be present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3546,10 +3546,10 @@ async function processGenericAccessTokenResponse(
       }
     }
 
-    if (requiredClaims.includes('auth_time') && claims.auth_time !== undefined) {
+    if (claims.auth_time !== undefined) {
       assertNumber(
         claims.auth_time,
-        false,
+        true,
         'ID Token "auth_time" (authentication time)',
         INVALID_RESPONSE,
         { claims },
@@ -5183,10 +5183,10 @@ async function validateHybridResponse(
     claims,
   })
 
-  if (requiredClaims.includes('auth_time') && claims.auth_time !== undefined) {
+  if (claims.auth_time !== undefined) {
     assertNumber(
       claims.auth_time,
-      false,
+      true,
       'ID Token "auth_time" (authentication time)',
       INVALID_RESPONSE,
       { claims },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3546,7 +3546,7 @@ async function processGenericAccessTokenResponse(
       }
     }
 
-    if (claims.auth_time !== undefined) {
+    if (requiredClaims.includes('auth_time') && claims.auth_time !== undefined) {
       assertNumber(
         claims.auth_time,
         false,
@@ -5183,7 +5183,7 @@ async function validateHybridResponse(
     claims,
   })
 
-  if (claims.auth_time !== undefined) {
+  if (requiredClaims.includes('auth_time') && claims.auth_time !== undefined) {
     assertNumber(
       claims.auth_time,
       false,

--- a/test/authorization_code.test.ts
+++ b/test/authorization_code.test.ts
@@ -776,13 +776,12 @@ test('processAuthorizationCodeResponse() nonce checks', async (t) => {
 
 test('processAuthorizationCodeResponse() auth_time checks', async (t) => {
   const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
-  const tClient = {...client , require_auth_time: true }
 
-  for (const auth_time of [0, -1, null, '1', [], {}, true]) {
+  for (const auth_time of [-1, null, '1', [], {}, true]) {
     await t.throwsAsync(
       lib.processAuthorizationCodeResponse(
         tIssuer,
-        tClient,
+        client,
         getResponse(
           JSON.stringify({
             access_token: 'token',
@@ -791,7 +790,7 @@ test('processAuthorizationCodeResponse() auth_time checks', async (t) => {
               .setProtectedHeader({ alg: 'RS256' })
               .setIssuer(issuer.issuer)
               .setSubject('urn:example:subject')
-              .setAudience(tClient.client_id)
+              .setAudience(client.client_id)
               .setExpirationTime('5m')
               .setIssuedAt()
               .sign(t.context.RS256.privateKey),

--- a/test/authorization_code.test.ts
+++ b/test/authorization_code.test.ts
@@ -776,12 +776,13 @@ test('processAuthorizationCodeResponse() nonce checks', async (t) => {
 
 test('processAuthorizationCodeResponse() auth_time checks', async (t) => {
   const tIssuer: lib.AuthorizationServer = { ...issuer, jwks_uri: endpoint('jwks') }
+  const tClient = {...client , require_auth_time: true }
 
   for (const auth_time of [0, -1, null, '1', [], {}, true]) {
     await t.throwsAsync(
       lib.processAuthorizationCodeResponse(
         tIssuer,
-        client,
+        tClient,
         getResponse(
           JSON.stringify({
             access_token: 'token',
@@ -790,7 +791,7 @@ test('processAuthorizationCodeResponse() auth_time checks', async (t) => {
               .setProtectedHeader({ alg: 'RS256' })
               .setIssuer(issuer.issuer)
               .setSubject('urn:example:subject')
-              .setAudience(client.client_id)
+              .setAudience(tClient.client_id)
               .setExpirationTime('5m')
               .setIssuedAt()
               .sign(t.context.RS256.privateKey),


### PR DESCRIPTION
### Summary

This change ensures that the `auth_time` claim is only validated when its value is actually required to be verified.

### Background

Some clients, such as Keycloak during user impersonation, provide a value of 0 for the `auth_time` claim. While the application might not need to verify the `auth_time` in these cases, the presence of 0 causes a failure because the system expects a positive value by default.

### Fix

With this update, the system will only validate the `auth_time` value when it's necessary. This prevents errors with clients that supply 0 for `auth_time` when it isn't intended to be checked.