### PR TITLE
Ensure as.issuer exists before validating against it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5582,7 +5582,7 @@ export function validateAuthResponse(
     throw OPE('response parameter "iss" (issuer) missing', INVALID_RESPONSE, { parameters })
   }
 
-  if (iss && iss !== as.issuer) {
+  if (iss && as.issuer && iss !== as.issuer) {
     throw OPE('unexpected "iss" (issuer) response parameter value', INVALID_RESPONSE, {
       expected: as.issuer,
       parameters,


### PR DESCRIPTION
This is potential fix for https://github.com/panva/oauth4webapi/issues/226

The [RFC](https://datatracker.ietf.org/doc/html/rfc9207#name-validating-the-issuer-ident) may not adequately handle this edge case (where the desired issuer is simply not known): 
> If the value does not match the expected issuer identifier, clients MUST reject the authorization response and MUST NOT proceed with the authorization grant.

> More precisely, clients that interact with authorization servers supporting OAuth metadata [[RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)] MUST compare the iss parameter value to the issuer value in the server's metadata document.

I think the "expected issuer identifier" is the unexpectedly problematic phrasing here - it doesn't exist in any form, which the authors likely didn't expect. The client was not configured with _any_ expected issuer, and no metadata document was ever fetched to fill in these values. 

For the sake of client compatibility and so that implementing the issuer parameter is not a breaking change for the AS, I would suggest that if there is no expected issuer identifier, then the provided issuer value cannot fail to match it and the request can continue as safely as it did before the `iss` value was provided. 

Openly, I don't know enough ts to add the tests for this in tap/callback though, I'm afraid. 

