### PR TITLE
feat: add ClientAssertion for JWT bearer client authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1714,6 +1714,7 @@ function formUrlEncode(token: string) {
  *
  * @see {@link ClientSecretPost}
  * @see {@link ClientSecretBasic}
+ * @see {@link ClientAssertion}
  * @see {@link PrivateKeyJwt}
  * @see {@link None}
  * @see {@link TlsClientAuth}
@@ -1725,6 +1726,13 @@ export type ClientAuth = (
   body: URLSearchParams,
   headers: Headers,
 ) => void | Promise<void>
+
+/**
+ * A function returning a JWT Bearer client assertion to be sent to the authorization server.
+ *
+ * @group Client Authentication
+ */
+export type ClientAssertionProvider = () => Promise<string>
 
 /**
  * **`client_secret_post`** uses the HTTP request body to send `client_id` and `client_secret` as
@@ -1784,6 +1792,37 @@ export function ClientSecretBasic(clientSecret: string): ClientAuth {
   }
 }
 
+/**
+ * Uses the HTTP request body to send `client_id`, `client_assertion_type`, and `client_assertion`
+ * as `application/x-www-form-urlencoded` body parameters. The JWT assertion is provided by the
+ * caller.
+ *
+ * @example
+ *
+ * ```ts
+ * let clientAssertionProvider!: oauth.ClientAssertionProvider
+ *
+ * let clientAuth = oauth.ClientAssertion(clientAssertionProvider)
+ * ```
+ *
+ * @param clientAssertionProvider
+ *
+ * @group Client Authentication
+ *
+ * @see [OAuth Token Endpoint Authentication Methods](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#token-endpoint-auth-method)
+ * @see [RFC 7523 - JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://www.rfc-editor.org/rfc/rfc7523.html#section-2.2)
+ * @see [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0-errata2.html#ClientAuthentication)
+ */
+export function ClientAssertion(clientAssertionProvider: ClientAssertionProvider): ClientAuth {
+  if (typeof clientAssertionProvider !== 'function') {
+    throw CodedTypeError('"clientAssertionProvider" must be a function', ERR_INVALID_ARG_TYPE)
+  }
+
+  return async (_as, client, body, _headers) => {
+    setClientAssertion(body, client, await clientAssertionProvider())
+  }
+}
+
 export interface ModifyAssertionOptions {
   /**
    * Use to modify a JWT assertion payload or header right before it is signed.
@@ -1838,9 +1877,7 @@ export function PrivateKeyJwt(
 
     options?.[modifyAssertion]?.(header, payload)
 
-    body.set('client_id', client.client_id)
-    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
-    body.set('client_assertion', await signJwt(header, payload, key))
+    setClientAssertion(body, client, await signJwt(header, payload, key))
   }
 }
 
@@ -1889,9 +1926,7 @@ export function ClientSecretJwt(
     const data = `${b64u(buf(JSON.stringify(header)))}.${b64u(buf(JSON.stringify(payload)))}`
     const hmac = await crypto.subtle.sign(key.algorithm, key, buf(data) as Uint8Array<ArrayBuffer>)
 
-    body.set('client_id', client.client_id)
-    body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
-    body.set('client_assertion', `${data}.${b64u(new Uint8Array(hmac))}`)
+    setClientAssertion(body, client, `${data}.${b64u(new Uint8Array(hmac))}`)
   }
 }
 
@@ -6792,3 +6827,10 @@ export const _nodiscoverycheck: unique symbol = Symbol()
  * @internal
  */
 export const _expectedIssuer: unique symbol = Symbol()
+
+function setClientAssertion(body: URLSearchParams, client: Client, clientAssertion: string) {
+  assertString(clientAssertion, '"clientAssertion"')
+  body.set('client_id', client.client_id)
+  body.set('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
+  body.set('client_assertion', clientAssertion)
+}

--- a/test/client_auth.test.ts
+++ b/test/client_auth.test.ts
@@ -98,6 +98,47 @@ test('client_secret_post', async (t) => {
   t.pass()
 })
 
+test('client_assertion', async (t) => {
+  let calls = 0
+
+  t.context
+    .intercept({
+      path: '/test-client-assertion',
+      method: 'POST',
+      headers(headers) {
+        return !('authorization' in headers)
+      },
+      body(body) {
+        const params = new URLSearchParams(body)
+        t.false(params.has('client_secret'))
+        t.is(params.get('client_id'), client.client_id)
+        t.is(
+          params.get('client_assertion_type'),
+          'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        )
+        t.is(params.get('client_assertion'), 'assertion')
+
+        return true
+      },
+    })
+    .reply(200, '')
+
+  await lib.revocationRequest(
+    { ...issuer, revocation_endpoint: endpoint('test-client-assertion') },
+    client,
+    lib.ClientAssertion(async () => {
+      calls++
+      return 'assertion'
+    }),
+    'token',
+  )
+
+  t.is(calls, 1)
+  t.throws(() => lib.ClientAssertion(null as any), {
+    message: '"clientAssertionProvider" must be a function',
+  })
+})
+
 test('private_key_jwt', async (t) => {
   const tIssuer = {
     ...issuer,

--- a/test/client_credentials.test.ts
+++ b/test/client_credentials.test.ts
@@ -83,6 +83,54 @@ test('clientCredentialsGrantRequest()', async (t) => {
   )
 })
 
+test('clientCredentialsGrantRequest() with client assertion', async (t) => {
+  let calls = 0
+
+  const tIssuer: lib.AuthorizationServer = {
+    ...issuer,
+    token_endpoint: endpoint('token-client-assertion'),
+  }
+
+  t.context
+    .intercept({
+      path: '/token-client-assertion',
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'user-agent': UA,
+      },
+      body(body) {
+        const params = new URLSearchParams(body)
+        return (
+          params.get('grant_type') === 'client_credentials' &&
+          params.get('resource') === 'urn:example:resource' &&
+          params.get('client_id') === client.client_id &&
+          !params.has('client_secret') &&
+          params.get('client_assertion_type') ===
+            'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
+          params.get('client_assertion') === 'assertion'
+        )
+      },
+    })
+    .reply(200, { access_token: 'token', token_type: 'Bearer' })
+
+  await t.notThrowsAsync(
+    lib.clientCredentialsGrantRequest(
+      tIssuer,
+      client,
+      lib.ClientAssertion(async () => {
+        calls++
+        return 'assertion'
+      }),
+      {
+        resource: 'urn:example:resource',
+      },
+    ),
+  )
+
+  t.is(calls, 1)
+})
+
 test('clientCredentialsGrantRequest() w/ Extra Parameters', async (t) => {
   const tIssuer: lib.AuthorizationServer = {
     ...issuer,


### PR DESCRIPTION
This PR adds the ability to authenticate with an arbitrary client assertion provider.

oauth4webapi already supported client assertions in which the library itself signs the JWT tokens (via private key or client secret).

By adding a generic `clientAssertionProvider`, users can supply assertions signed by an external source, such as a cloud platform (works on Azure and Vercel, among others), Kubernetes, etc

This is compliant with RFC 7523

Example usage:

```js
import * as oauth from 'oauth4webapi'

const as: oauth.AuthorizationServer = {
  issuer: 'https://issuer.example.com',
  token_endpoint: 'https://issuer.example.com/oauth/token',
}

const client: oauth.Client = {
  client_id: 'my-client-id',
  // no client_secret
}

const clientAuth = oauth.ClientAssertion(async () => {
  // Provide the assertion somehow
  const assertion = '...'
  return assertion
})

const response = await oauth.clientCredentialsGrantRequest(as, client, clientAuth, {
  scope: 'read:things',
})

const result = await oauth.processClientCredentialsResponse(as, client, response)

console.log(result.access_token)
```